### PR TITLE
Add World Cup 2026 and Love Island Villa to portfolio projects

### DIFF
--- a/src/components/IPhoneView.jsx
+++ b/src/components/IPhoneView.jsx
@@ -8,6 +8,22 @@ const TECHS = [
 
 const PROJECTS = [
   {
+    name: 'World Cup 2026',
+    desc: 'Live schedule, standings, bracket, and pick’em for the 2026 World Cup.',
+    icon: '⚽',
+    links: [
+      { label: 'Live Site', url: 'https://worldcupppp.netlify.app/' },
+    ],
+  },
+  {
+    name: 'Love Island Villa',
+    desc: 'Drag-and-drop couples tracker for Love Island USA — recouple the villa, rank islanders, keep notes.',
+    icon: '🏝️',
+    links: [
+      { label: 'Live Site', url: 'https://loveislandvilla.netlify.app/' },
+    ],
+  },
+  {
     name: 'The Period Collective',
     desc: 'Nonprofit providing menstrual products to people in need in Chicago.',
     icon: '🌸',

--- a/src/components/windows/PortfolioContent.jsx
+++ b/src/components/windows/PortfolioContent.jsx
@@ -2,6 +2,22 @@ import { useNetscape } from '../NetscapeContext.jsx';
 
 const projects = [
   {
+    name: 'World Cup 2026',
+    desc: 'Live schedule, standings, bracket, and pick’em for the 2026 World Cup.',
+    icon: '⚽',
+    links: [
+      { label: 'Live Site', url: 'https://worldcupppp.netlify.app/', embeddable: true },
+    ],
+  },
+  {
+    name: 'Love Island Villa',
+    desc: 'Drag-and-drop couples tracker for Love Island USA — recouple the villa, rank islanders, keep notes.',
+    icon: '🏝️',
+    links: [
+      { label: 'Live Site', url: 'https://loveislandvilla.netlify.app/', embeddable: true },
+    ],
+  },
+  {
     name: 'The Period Collective',
     desc: 'Nonprofit providing menstrual products to people in need in Chicago.',
     icon: '🌸',


### PR DESCRIPTION
## What

Adds two recent Netlify Drop deploys that weren't listed anywhere on the portfolio:

| Project | Link | Published |
|---|---|---|
| ⚽ World Cup 2026 | worldcupppp.netlify.app | Jul 16 |
| 🏝️ Love Island Villa | loveislandvilla.netlify.app | Jun 26 |

Both go at the top of the list, newest first.

## Why two files

The desktop and mobile views keep **separate** project arrays — `projects` in `PortfolioContent.jsx` and `PROJECTS` in `IPhoneView.jsx` — so each project is added in both places. Worth knowing for future additions; they will silently drift otherwise.

## Details

- **Desktop entries are marked `embeddable: true`.** I checked both sites' response headers — neither sends `X-Frame-Options` nor a `frame-ancestors` CSP, so they render inside the Netscape window instead of opening a new tab. The mobile entries are plain external links, matching how the other projects behave there.
- **Live Site is the only link on each.** Both were deployed via Netlify Drop, so there's no linked repo to point a GitHub link at.

## Verification

`npm run build` passes.

Note: the build was broken in this repo before this change — `@rollup/rollup-darwin-arm64` was missing from `node_modules` ([npm/cli#4828](https://github.com/npm/cli/issues/4828)). I worked around it locally with `npm i --no-save`, leaving the lockfile untouched. If Netlify builds hit the same error, the durable fix is removing `node_modules` and `package-lock.json` and re-running `npm i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)