### PR TITLE
Ignore Vite dist output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
Adds `/dist` to `.gitignore`. The ignore list only covered `/build` from the Create React App days; the project builds with Vite now and `netlify.toml` publishes from `dist`, so build output sat untracked and could be swept into a commit by an absent-minded `git add -A`.

## Rewritten from the original version of this PR

This PR previously also regenerated `package-lock.json`, justified by a claim that turned out to be wrong. I said the lockfile was missing the platform-specific rollup binary that broke `npm run build`. It wasn't — both the old and new lockfiles list all 25 platform variants, including `rollup-linux-x64-gnu`. The broken state was purely my local `node_modules`, which a reinstall fixed.

Netlify's builds were never affected: the deploy logs show clean builds with no `Cannot find module` errors. So the lockfile churn (and the incidental react-icons 5.6.0 → 5.7.0 and sass 1.98.0 → 1.103.1 bumps that came with it) bought nothing while touching a file production builds from. It's dropped.

Also retargeted from `main` to `master`, which is the branch Netlify actually deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)