### PR TITLE
Merge main into master: add World Cup 2026 and Love Island Villa

### DIFF
--- a/src/components/IPhoneView.jsx
+++ b/src/components/IPhoneView.jsx
@@ -8,6 +8,22 @@ const TECHS = [
 
 const PROJECTS = [
   {
+    name: 'World Cup 2026',
+    desc: 'Live schedule, standings, bracket, and pick’em for the 2026 World Cup.',
+    icon: '⚽',
+    links: [
+      { label: 'Live Site', url: 'https://worldcupppp.netlify.app/' },
+    ],
+  },
+  {
+    name: 'Love Island Villa',
+    desc: 'Drag-and-drop couples tracker for Love Island USA — recouple the villa, rank islanders, keep notes.',
+    icon: '🏝️',
+    links: [
+      { label: 'Live Site', url: 'https://loveislandvilla.netlify.app/' },
+    ],
+  },
+  {
     name: 'The Period Collective',
     desc: 'Nonprofit providing menstrual products to people in need in Chicago.',
     icon: '🌸',

--- a/src/components/windows/PortfolioContent.jsx
+++ b/src/components/windows/PortfolioContent.jsx
@@ -2,6 +2,22 @@ import { useNetscape } from '../NetscapeContext.jsx';
 
 const projects = [
   {
+    name: 'World Cup 2026',
+    desc: 'Live schedule, standings, bracket, and pick’em for the 2026 World Cup.',
+    icon: '⚽',
+    links: [
+      { label: 'Live Site', url: 'https://worldcupppp.netlify.app/', embeddable: true },
+    ],
+  },
+  {
+    name: 'Love Island Villa',
+    desc: 'Drag-and-drop couples tracker for Love Island USA — recouple the villa, rank islanders, keep notes.',
+    icon: '🏝️',
+    links: [
+      { label: 'Live Site', url: 'https://loveislandvilla.netlify.app/', embeddable: true },
+    ],
+  },
+  {
     name: 'The Period Collective',
     desc: 'Nonprofit providing menstrual products to people in need in Chicago.',
     icon: '🌸',


### PR DESCRIPTION
## Why this PR exists

`master` is the branch Netlify deploys (production branch on site `elastic-hermann-52302a`, with branch deploys restricted to the production branch only). The World Cup 2026 and Love Island Villa entries were merged into `main` in #46, which nothing deploys from — so they never reached the live site.

This brings them onto `master`, which will trigger a production deploy on merge.

## What changes

Exactly the two project-list additions, +32 lines:

- `src/components/windows/PortfolioContent.jsx` — desktop list
- `src/components/IPhoneView.jsx` — mobile list

## What is preserved

`master` has work that `main` does not, and this merge keeps all of it:

- The **Cute Sudoku** project in both project lists
- The **Google Analytics** tag in `index.html`
- `IpodView.jsx` changes

Verified locally: merging `main` into `master` produces zero conflicts and a diff of exactly the 32 added lines above. Nothing on `master` is removed.

> Worth deciding separately: `main` is now missing Cute Sudoku and the GA tag, so the two branches will keep diverging. Either merge `master` back into `main` after this lands, or retire `main` and branch future work off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)